### PR TITLE
修复数据库不是默认3306端口，框架连接不了数据库bug

### DIFF
--- a/src/admin/src/config/config.php
+++ b/src/admin/src/config/config.php
@@ -8,6 +8,7 @@ return [
             'username' => env('HYPERF_ADMIN_DB_USER'),
             'password' => env('HYPERF_ADMIN_DB_PWD'),
             'prefix' => env('HYPERF_ADMIN_DB_PREFIX'),
+            'port' => env('HYPERF_ADMIN_DB_PORT'),
         ]),
     ],
     'init_routes' => [

--- a/src/config-center/src/ConfigProvider.php
+++ b/src/config-center/src/ConfigProvider.php
@@ -15,6 +15,7 @@ class ConfigProvider
                     'username' => env('CONFIG_CENTER_DB_USER', env('HYPERF_ADMIN_DB_USER')),
                     'password' => env('CONFIG_CENTER_DB_PWD', env('HYPERF_ADMIN_DB_PWD')),
                     'prefix' => env('CONFIG_CENTER_DB_PREFIX', env('HYPERF_ADMIN_DB_PREFIX')),
+                    'port' => env('CONFIG_CENTER_DB_PORT', env('HYPERF_ADMIN_DB_PORT')),
                 ]),
             ],
             'commands' => [

--- a/src/cron-center/src/ConfigProvider.php
+++ b/src/cron-center/src/ConfigProvider.php
@@ -20,7 +20,7 @@ class ConfigProvider
                     'username' => env('CRON_CENTER_DB_USER', env('HYPERF_ADMIN_DB_USER')),
                     'password' => env('CRON_CENTER_DB_PWD', env('HYPERF_ADMIN_DB_PWD')),
                     'prefix' => env('CRON_CENTER_DB_PREFIX', env('HYPERF_ADMIN_DB_PREFIX')),
-
+                    'port' => env('CRON_CENTER_DB_PORT', env('HYPERF_ADMIN_DB_PORT')),
                 ]),
             ],
             'commands' => [

--- a/src/data-focus/src/ConfigProvider.php
+++ b/src/data-focus/src/ConfigProvider.php
@@ -17,7 +17,7 @@ class ConfigProvider
                     'username' => env('DATA_FOCUS_DB_USER', env('HYPERF_ADMIN_DB_USER')),
                     'password' => env('DATA_FOCUS_DB_PWD', env('HYPERF_ADMIN_DB_PWD')),
                     'prefix' => env('DATA_FOCUS_DB_PREFIX', env('HYPERF_ADMIN_DB_PREFIX')),
-
+                    'port' => env('DATA_FOCUS_DB_PORT', env('HYPERF_ADMIN_DB_PORT')),
                 ]),
             ],
             'commands' => [


### PR DESCRIPTION
按照文档安装流程走，由于我用的线上数据库不是默认的3306端口，始终跑不通，就追代码修复了这个bug。