### PR TITLE
build(composer): 限制 flysystem-oss 的版本

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "hyperf/snowflake": "~2.2.0",
         "hyperf/validation": "~2.2.0",
         "nette/php-generator": "^3.4",
-        "xxtime/flysystem-aliyun-oss": "^1.5",
+        "xxtime/flysystem-aliyun-oss": "~1.5",
         "yadakhov/insert-on-duplicate-key": "^1.2",
         "zoujingli/ip2region": "^1.0"
     },


### PR DESCRIPTION
该库未遵循 SemVer，使用 ^ 会更新到不向后兼容的版本