### PR TITLE
fix(scaffold): 不再强制转换级联菜单项的值为整型

### DIFF
--- a/src/base-utils/src/Scaffold/Controller/AbstractController.php
+++ b/src/base-utils/src/Scaffold/Controller/AbstractController.php
@@ -827,7 +827,7 @@ abstract class AbstractController extends Controller
             switch ($_form['type']) {
                 case 'checkbox':
                 case 'cascader':
-                    $_form['value'] = array_map('intval', is_array($_form['value']) ? $_form['value'] : (array)$_form['value']);
+                    $_form['value'] = (array)$_form['value'];
                     break;
                 case 'image':
                     $biz['props']['limit'] = $biz['props']['limit'] ?? 1;


### PR DESCRIPTION
某些需要字符型值的场景会无法匹配，遵循用户意愿，不强制转换